### PR TITLE
Removed _PS_USE_SQL_SLAVE_ flag in DM queries

### DIFF
--- a/esatisfaction.php
+++ b/esatisfaction.php
@@ -60,7 +60,7 @@ class Esatisfaction extends Module
      */
     public function install()
     {
-        Db::getInstance(_PS_USE_SQL_SLAVE_)->Execute('CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'esat_order_stat` (
+        Db::getInstance()->Execute('CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'esat_order_stat` (
         `order_id` INT( 11 ) NOT NULL,
         `item_id` VARCHAR(100) NOT NULL,
         KEY `order_id` (`order_id`),
@@ -695,7 +695,7 @@ class Esatisfaction extends Module
      */
     public function insertQueueItem($order_id, $item_id)
     {
-        return Db::getInstance(_PS_USE_SQL_SLAVE_)->insert(
+        return Db::getInstance()->insert(
             'esat_order_stat',
             array('order_id' => $order_id, 'item_id' => $item_id),
             false,
@@ -731,6 +731,6 @@ class Esatisfaction extends Module
      */
     public function deleteQueueItem($order_id)
     {
-        Db::getInstance(_PS_USE_SQL_SLAVE_)->delete('esat_order_stat', 'order_id = '.$order_id);
+        Db::getInstance()->delete('esat_order_stat', 'order_id = '.$order_id);
     }
 }


### PR DESCRIPTION
Data manipulation queries must use the Master database in master-slave replication setups. 
Slave databases should be used only for data retrieval.