### PR TITLE
Fix integration with/without jQuery load

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -8,6 +8,7 @@ To get the diff for a specific change, go to https://github.com/esatisfaction/es
 XXX is the change hash
 
 * 1.0.4 (future-release)
+  * Fix integration logic to get jQuery version properly
 * 1.0.3 (2019-02-28)
   * Update the integration script to match the latest (25th February, 2019) e-satisfaction integration guidelines.
 * 1.0.2 (2019-01-17)

--- a/views/templates/hook/header.tpl
+++ b/views/templates/hook/header.tpl
@@ -29,7 +29,7 @@
         doc.addEventListener('DOMContentLoaded', function () {
             var body = doc.getElementsByTagName('body')[0], script = doc.createElement('script');
             script.async = true;
-            script.src = 'https://collection.e-satisfaction.com/dist/js/integration' + (!!jq ? '' : '.jq') + '.min.js';
+            script.src = 'https://collection.e-satisfaction.com/dist/js/integration' + (!!jq ? '.jq' : '') + '.min.js';
             body.appendChild(script);
         });
     })(window, document, "{/literal}{$app_id|escape:'htmlall':'UTF-8'}{literal}", false, {});


### PR DESCRIPTION
The logic didn't work the way it was supposed to.
If we **DID NOT** want jQuery in our integration you had to pass **"true"** in the parameters which didn't make sense.

