### PR TITLE
Change $is_store_pickup variable from boolean to string

### DIFF
--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -8,6 +8,7 @@ To get the diff for a specific change, go to https://github.com/esatisfaction/es
 XXX is the change hash
 
 * 1.0.5 (future-release)
+  * Change $is_store_pickup variable from boolean to string
 * 1.0.4 (2019-03-05)
   * Fix integration logic to get jQuery version properly
 * 1.0.3 (2019-02-28)

--- a/esatisfaction.php
+++ b/esatisfaction.php
@@ -468,7 +468,7 @@ class Esatisfaction extends Module
         $is_store_pickup = (in_array(
             $carrier->id_reference,
             json_decode(Configuration::get('ESATISFACTION_STOREPICKUP_IDS'))
-        )) ? true : false;
+        )) ? 'true' : 'false';
 
         $app_id = Configuration::get('ESATISFACTION_APP_ID');
         $quest_id = Configuration::get('ESATISFACTION_CHKOUTID');


### PR DESCRIPTION
We change the variable to string to avoid functionality break when order isn't store pickup.
This happens because the false doesn't add a value in the metadata so we end up with: 
`questionnaire: {`
`           ` `"transaction_id": "7",`
`           ` `"transaction_date": "2019-03-12 13:08:46",`
`           ` ` "store_pickup": `
` }`.
 which is wrong.