### PR TITLE
Include order reference in transaction_id metadata (Presta 1.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ in all versions (major and minor)
 To get the diff for a specific change, go to https://github.com/esatisfaction/esat-prestashop/commit/XXX where
 XXX is the change hash
 
+* 1.1.1
+  * Include order reference in transaction_id metadata
 * 1.1.0
   * Use e-satisfaction working domain
   * Work with api v3.2

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 e-satisfaction SA
+Copyright (c) 2020 e-satisfaction.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>esatisfaction</name>
     <displayName><![CDATA[E-satisfaction Module]]></displayName>
-    <version><![CDATA[1.1.0]]></version>
+    <version><![CDATA[1.1.1]]></version>
     <description><![CDATA[Adds the code necessary to gather customer satisfaction data]]></description>
     <author><![CDATA[e-satisfaction SA]]></author>
     <tab><![CDATA[analytics_stats]]></tab>

--- a/config.xml
+++ b/config.xml
@@ -4,7 +4,7 @@
     <displayName><![CDATA[E-satisfaction Module]]></displayName>
     <version><![CDATA[1.1.1]]></version>
     <description><![CDATA[Adds the code necessary to gather customer satisfaction data]]></description>
-    <author><![CDATA[e-satisfaction SA]]></author>
+    <author><![CDATA[e-satisfaction.com]]></author>
     <tab><![CDATA[analytics_stats]]></tab>
     <is_configurable>1</is_configurable>
     <need_instance>0</need_instance>

--- a/esatisfaction.php
+++ b/esatisfaction.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * NOTICE OF LICENSE.
  *
@@ -8,12 +9,15 @@
  *
  * You must not modify, adapt or create derivative works of this source code
  *
- * @author    e-satisfaction SA
- * @copyright 2018 e-satisfaction SA
+ * @author    e-satisfaction.com
+ * @copyright 2020, e-satisfaction.com
  * @license   https://opensource.org/licenses
  * @version   1.1.1
  */
 
+/**
+ * Class Esatisfaction
+ */
 class Esatisfaction extends Module
 {
     /**
@@ -34,7 +38,7 @@ class Esatisfaction extends Module
         $this->name = 'esatisfaction';
         $this->tab = 'other';
         $this->version = '1.1.1';
-        $this->author = 'e-satisfaction SA';
+        $this->author = 'e-satisfaction.com';
         $this->tab = 'analytics_stats';
         $this->need_instance = 0;
         $this->ps_versions_compliancy = ['min' => '1.6', 'max' => '1.6.99.99'];
@@ -55,8 +59,9 @@ class Esatisfaction extends Module
      * displayBackOfficeHeader
      *
      * @return bool
-     * @copyright (c) 2018, e-satisfaction SA
-     * @author        e-satisfaction SA
+     *
+     * @copyright (c) 2020, e-satisfaction.com
+     * @author        e-satisfaction.com
      */
     public function install()
     {
@@ -75,6 +80,9 @@ class Esatisfaction extends Module
 
     /**
      * @return bool
+     *
+     * @copyright (c) 2020, e-satisfaction.com
+     * @author        e-satisfaction.com
      */
     public function uninstall()
     {
@@ -85,8 +93,9 @@ class Esatisfaction extends Module
      * Load the configuration page.
      *
      * @return string
-     * @copyright (c) 2018, e-satisfaction SA
-     * @author        e-satisfaction SA
+     *
+     * @copyright (c) 2020, e-satisfaction.com
+     * @author        e-satisfaction.com
      */
     public function getContent()
     {
@@ -129,8 +138,9 @@ class Esatisfaction extends Module
      * Display the configuration form.
      *
      * @return string
-     * @copyright (c) 2018, e-satisfaction SA
-     * @author        e-satisfaction SA
+     *
+     * @copyright (c) 2020, e-satisfaction.com
+     * @author        e-satisfaction.com
      */
     public function displayForm()
     {
@@ -443,9 +453,8 @@ class Esatisfaction extends Module
      *
      * @param array $params
      *
-     * @copyright (c) 2018, e-satisfaction SA
-     *
-     * @author        e-satisfaction SA
+     * @copyright (c) 2020, e-satisfaction.com
+     * @author        e-satisfaction.com
      */
     public function hookDisplayBackOfficeHeader($params)
     {
@@ -462,9 +471,9 @@ class Esatisfaction extends Module
      * @param array $params
      *
      * @return bool
-     * @author        e-satisfaction SA
-     * @copyright (c) 2018, e-satisfaction SA
      *
+     * @copyright (c) 2020, e-satisfaction.com
+     * @author        e-satisfaction.com
      */
     public function hookDisplayOrderConfirmation($params)
     {
@@ -502,9 +511,9 @@ class Esatisfaction extends Module
      * @param array $params
      *
      * @return string
-     * @author        e-satisfaction SA
-     * @copyright (c) 2018, e-satisfaction SA
      *
+     * @copyright (c) 2020, e-satisfaction.com
+     * @author        e-satisfaction.com
      */
     public function hookDisplayHeader($params)
     {
@@ -521,9 +530,9 @@ class Esatisfaction extends Module
      * @param array $params
      *
      * @throws Exception
-     * @author        e-satisfaction SA
-     * @copyright (c) 2018, e-satisfaction SA
      *
+     * @copyright (c) 2020, e-satisfaction.com
+     * @author        e-satisfaction.com
      */
     public function hookActionOrderStatusPostUpdate($params)
     {
@@ -565,9 +574,9 @@ class Esatisfaction extends Module
      * @param array  $extra_options
      *
      * @return mixed
-     * @author        e-satisfaction SA
-     * @copyright (c) 2018, e-satisfaction SA
      *
+     * @copyright (c) 2020, e-satisfaction.com
+     * @author        e-satisfaction.com
      */
     public function makeApiCall($url, $data, $expected_code, $method = null, $extra_options = [])
     {
@@ -613,9 +622,9 @@ class Esatisfaction extends Module
      * @param bool   $is_store_pickup
      *
      * @throws Exception
-     * @copyright (c) 2018, e-satisfaction SA
      *
-     * @author        e-satisfaction SA
+     * @copyright (c) 2020, e-satisfaction.com
+     * @author        e-satisfaction.com
      */
     public function sendQuestionnaire($order_obj, $customer, $invoice_address, $is_store_pickup)
     {
@@ -662,9 +671,8 @@ class Esatisfaction extends Module
      *
      * @param object $order_obj
      *
-     * @copyright (c) 2018, e-satisfaction SA
-     *
-     * @author        e-satisfaction SA
+     * @copyright (c) 2020, e-satisfaction.com
+     * @author        e-satisfaction.com
      */
     public function cancelQuestionnaire($order_obj)
     {
@@ -687,9 +695,9 @@ class Esatisfaction extends Module
      * @param string $item_id
      *
      * @return bool
-     * @copyright (c) 2018, e-satisfaction SA
      *
-     * @author        e-satisfaction SA
+     * @copyright (c) 2020, e-satisfaction.com
+     * @author        e-satisfaction.com
      */
     public function insertQueueItem($order_id, $item_id)
     {
@@ -708,9 +716,9 @@ class Esatisfaction extends Module
      * @param int $order_id
      *
      * @return bool
-     * @author        e-satisfaction SA
-     * @copyright (c) 2018, e-satisfaction SA
      *
+     * @copyright (c) 2020, e-satisfaction.com
+     * @author        e-satisfaction.com
      */
     public function getQueueItem($order_id)
     {
@@ -724,9 +732,8 @@ class Esatisfaction extends Module
      *
      * @param int $order_id
      *
-     * @copyright (c) 2018, e-satisfaction SA
-     *
-     * @author        e-satisfaction SA
+     * @copyright (c) 2020, e-satisfaction.com
+     * @author        e-satisfaction.com
      */
     public function deleteQueueItem($order_id)
     {

--- a/esatisfaction.php
+++ b/esatisfaction.php
@@ -631,7 +631,7 @@ class Esatisfaction extends Module
             'locale' => Language::getIsoById($customer->id_lang),
             'metadata' => array(
                 'questionnaire' => array(
-                    'transaction_id' => $order_obj->id,
+                    'transaction_id' => sprintf('%s (%s)', $order_obj->id, $order_obj->reference),
                     'transaction_date' => $order_obj->date_add,
                 ),
                 'responder' => array(

--- a/esatisfaction.php
+++ b/esatisfaction.php
@@ -11,7 +11,7 @@
  * @author    e-satisfaction SA
  * @copyright 2018 e-satisfaction SA
  * @license   https://opensource.org/licenses
- * @version   1.1.0
+ * @version   1.1.1
  */
 
 class Esatisfaction extends Module
@@ -33,11 +33,11 @@ class Esatisfaction extends Module
     {
         $this->name = 'esatisfaction';
         $this->tab = 'other';
-        $this->version = '1.1.0';
+        $this->version = '1.1.1';
         $this->author = 'e-satisfaction SA';
         $this->tab = 'analytics_stats';
         $this->need_instance = 0;
-        $this->ps_versions_compliancy = array('min' => '1.6', 'max' => '1.6.99.99');
+        $this->ps_versions_compliancy = ['min' => '1.6', 'max' => '1.6.99.99'];
         $this->module_key = '5cd651fbc7befadc249391eb1ef2bf7d';
         $this->bootstrap = true;
         parent::__construct();
@@ -54,9 +54,9 @@ class Esatisfaction extends Module
      * actionOrderStatusPostUpdate, displayHeader,
      * displayBackOfficeHeader
      *
-     * @author        e-satisfaction SA
-     * @copyright (c) 2018, e-satisfaction SA
      * @return bool
+     * @copyright (c) 2018, e-satisfaction SA
+     * @author        e-satisfaction SA
      */
     public function install()
     {
@@ -84,9 +84,9 @@ class Esatisfaction extends Module
     /**
      * Load the configuration page.
      *
-     * @author        e-satisfaction SA
-     * @copyright (c) 2018, e-satisfaction SA
      * @return string
+     * @copyright (c) 2018, e-satisfaction SA
+     * @author        e-satisfaction SA
      */
     public function getContent()
     {
@@ -128,9 +128,9 @@ class Esatisfaction extends Module
     /**
      * Display the configuration form.
      *
-     * @author        e-satisfaction SA
-     * @copyright (c) 2018, e-satisfaction SA
      * @return string
+     * @copyright (c) 2018, e-satisfaction SA
+     * @author        e-satisfaction SA
      */
     public function displayForm()
     {
@@ -140,229 +140,229 @@ class Esatisfaction extends Module
         $default_lang = (int)Configuration::get('PS_LANG_DEFAULT');
 
         $carriers_raw = Carrier::getCarriers($default_lang, true, false);
-        $carriers = array();
+        $carriers = [];
         foreach ($carriers_raw as $carrier) {
-            $carriers[] = array(
+            $carriers[] = [
                 'val' => $carrier['id_reference'],
                 'carrier_reference' => $carrier['id_reference'],
-                'name' => $carrier['name'], );
+                'name' => $carrier['name'],];
         }
 
         $order_statuses_raw = OrderState::getOrderStates($default_lang);
-        $order_statuses = array();
+        $order_statuses = [];
         foreach ($order_statuses_raw as $order_status) {
-            $order_statuses[] = array(
+            $order_statuses[] = [
                 'val' => $order_status['id_order_state'],
                 'order_state_id' => $order_status['id_order_state'],
                 'name' => $order_status['name'],
-            );
+            ];
         }
 
         // Init Fields form array
-        $fields_form[0]['form'] = array(
-            'legend' => array(
+        $fields_form[0]['form'] = [
+            'legend' => [
                 'title' => $this->l('Application'),
-            ),
-            'input' => array(
-                array(
+            ],
+            'input' => [
+                [
                     'type' => 'text',
                     'label' => $this->l('Application Id'),
                     'name' => 'ESATISFACTION_APP_ID',
                     'size' => 20,
                     'required' => true,
-                ),
-                array(
+                ],
+                [
                     'type' => 'text',
                     'label' => $this->l('Working Domain'),
                     'name' => 'ESATISFACTION_DOMAIN',
                     'size' => 20,
                     'required' => true,
-                ),
-            ),
-            'submit' => array(
+                ],
+            ],
+            'submit' => [
                 'title' => $this->l('Save'),
                 'class' => 'btn btn-default',
-            ),
-        );
-        $fields_form[1]['form'] = array(
-            'legend' => array(
+            ],
+        ];
+        $fields_form[1]['form'] = [
+            'legend' => [
                 'title' => $this->l('Checkout Questionnaire'),
-            ),
-            'input' => array(
-                array(
+            ],
+            'input' => [
+                [
                     'type' => 'text',
                     'label' => $this->l('Questionnaire Id'),
                     'name' => 'ESATISFACTION_CHKOUTID',
                     'size' => 45,
                     'required' => true,
-                ),
-            ),
-            'submit' => array(
+                ],
+            ],
+            'submit' => [
                 'title' => $this->l('Save'),
                 'class' => 'btn btn-default',
-            ),
-        );
+            ],
+        ];
 
-        $fields_form[2]['form'] = array(
-            'legend' => array(
+        $fields_form[2]['form'] = [
+            'legend' => [
                 'title' => $this->l('Manually sending After Delivery / Store Pickup'),
-            ),
-            'input' => array(
-                array(
+            ],
+            'input' => [
+                [
                     'type' => 'switch',
                     'label' => $this->l('Send Manually'),
                     'name' => 'manual_send',
                     'is_bool' => true,
-                    'values' => array(
-                        array(
+                    'values' => [
+                        [
                             'id' => 'manual_send_on',
                             'value' => 1,
                             'label' => $this->l('Enabled'),
-                        ),
-                        array(
+                        ],
+                        [
                             'id' => 'manual_send_off',
                             'value' => 0,
                             'label' => $this->l('Disabled'),
-                        ),
-                    ),
-                ),
-            ),
-            'submit' => array(
+                        ],
+                    ],
+                ],
+            ],
+            'submit' => [
                 'title' => $this->l('Save'),
                 'class' => 'btn btn-default',
-            ),
-        );
+            ],
+        ];
 
-        $fields_form[3]['form'] = array(
-            'legend' => array(
+        $fields_form[3]['form'] = [
+            'legend' => [
                 'title' => $this->l('API Authentication Token'),
-            ),
-            'input' => array(
-                array(
+            ],
+            'input' => [
+                [
                     'type' => 'text',
                     'label' => $this->l('Token'),
                     'name' => 'ESATISFACTION_AUTH',
                     'size' => 45,
-                ),
-            ),
-            'submit' => array(
+                ],
+            ],
+            'submit' => [
                 'title' => $this->l('Save'),
                 'class' => 'btn btn-default',
-            ),
-        );
+            ],
+        ];
 
-        $fields_form[4]['form'] = array(
-            'legend' => array(
+        $fields_form[4]['form'] = [
+            'legend' => [
                 'title' => $this->l('After Delivery Questionnaire'),
-            ),
-            'input' => array(
-                array(
+            ],
+            'input' => [
+                [
                     'type' => 'text',
                     'label' => $this->l('Questionnaire Id'),
                     'name' => 'ESATISFACTION_HOMEDLVID',
                     'size' => 45,
-                ),
-                array(
+                ],
+                [
                     'type' => 'text',
                     'label' => $this->l('Pipeline Id'),
                     'name' => 'ESATISFACTION_HOMEDLV_PIPE_ID',
                     'size' => 45,
-                ),
-                array(
+                ],
+                [
                     'type' => 'text',
                     'label' => $this->l('Days after to send questionnaire'),
                     'name' => 'ESATISFACTION_HOMEDLVID_DAYS',
                     'size' => 4,
-                ),
-                array(
+                ],
+                [
                     'type' => 'checkbox',
                     'label' => $this->l('Order status(es) to send questionnaire'),
                     'name' => 'delivered_dlv_os[]',
-                    'values'  => array(
-                       'query' => $order_statuses,
-                       'id' => 'order_state_id',
-                       'name'  => 'name',
-                    ),
-                ),
-                array(
+                    'values' => [
+                        'query' => $order_statuses,
+                        'id' => 'order_state_id',
+                        'name' => 'name',
+                    ],
+                ],
+                [
                     'type' => 'checkbox',
                     'label' => $this->l('Condition to determine when it’s after delivery'),
                     'name' => 'courier_carriers[]',
                     'desc' => 'Select the carriers that are used for after delivery',
-                    'values'  => array(
-                       'query' => $carriers,
-                       'id' => 'carrier_reference',
-                       'name'  => 'name',
-                ), ),
-                array(
+                    'values' => [
+                        'query' => $carriers,
+                        'id' => 'carrier_reference',
+                        'name' => 'name',
+                    ],],
+                [
                     'type' => 'checkbox',
                     'label' => $this->l('Order status(es) to cancel questionnaire'),
                     'name' => 'canceled_dlv_os[]',
-                    'values'  => array(
-                       'query' => $order_statuses,
-                       'id' => 'order_state_id',
-                       'name'  => 'name',
-                    ),
-                ),
-            ),
-            'submit' => array(
+                    'values' => [
+                        'query' => $order_statuses,
+                        'id' => 'order_state_id',
+                        'name' => 'name',
+                    ],
+                ],
+            ],
+            'submit' => [
                 'title' => $this->l('Save'),
                 'class' => 'btn btn-default',
-            ),
-        );
-        $fields_form[5]['form'] = array(
-            'legend' => array(
+            ],
+        ];
+        $fields_form[5]['form'] = [
+            'legend' => [
                 'title' => $this->l('Store Pick Up Questionnaire'),
-            ),
-            'input' => array(
-                array(
+            ],
+            'input' => [
+                [
                     'type' => 'text',
                     'label' => $this->l('Questionnaire Id'),
                     'name' => 'ESATISFACTION_STRPICKID',
                     'size' => 45,
-                ),
-                array(
+                ],
+                [
                     'type' => 'text',
                     'label' => $this->l('Pipeline Id'),
                     'name' => 'ESATISFACTION_STRPICK_PIPE_ID',
                     'size' => 45,
-                ),
-                array(
+                ],
+                [
                     'type' => 'checkbox',
                     'label' => $this->l('Order status(es) to send questionnaire'),
                     'name' => 'delivered_strpick_os[]',
-                    'values'  => array(
-                       'query' => $order_statuses,
-                       'id' => 'order_state_id',
-                       'name'  => 'name',
-                    ),
-                ),
-                array(
+                    'values' => [
+                        'query' => $order_statuses,
+                        'id' => 'order_state_id',
+                        'name' => 'name',
+                    ],
+                ],
+                [
                     'type' => 'checkbox',
                     'label' => $this->l('Condition to determine when it’s store pickup'),
                     'name' => 'store_pickup_carriers[]',
                     'desc' => 'Select the carriers that are used for store pickup',
-                    'values'  => array(
-                       'query' => $carriers,
-                       'id' => 'carrier_reference',
-                       'name'  => 'name',
-                ), ),
-                array(
+                    'values' => [
+                        'query' => $carriers,
+                        'id' => 'carrier_reference',
+                        'name' => 'name',
+                    ],],
+                [
                     'type' => 'checkbox',
                     'label' => $this->l('Order status(es) to cancel questionnaire'),
                     'name' => 'canceled_strpick_os[]',
-                    'values'  => array(
-                       'query' => $order_statuses,
-                       'id' => 'order_state_id',
-                       'name'  => 'name',
-                    ),
-                ),
-            ),
-            'submit' => array(
+                    'values' => [
+                        'query' => $order_statuses,
+                        'id' => 'order_state_id',
+                        'name' => 'name',
+                    ],
+                ],
+            ],
+            'submit' => [
                 'title' => $this->l('Save'),
                 'class' => 'btn btn-default',
-            ),
-        );
+            ],
+        ];
 
         $helper = new HelperForm();
 
@@ -381,17 +381,17 @@ class Esatisfaction extends Module
         $helper->show_toolbar = true; // false -> remove toolbar
         $helper->toolbar_scroll = true;      // yes - > Toolbar is always visible on the top of the screen.
         $helper->submit_action = 'submit' . $this->name;
-        $helper->toolbar_btn = array(
-            'save' => array(
+        $helper->toolbar_btn = [
+            'save' => [
                 'desc' => $this->l('Save'),
                 'href' => AdminController::$currentIndex . '&configure=' . $this->name . '&save' . $this->name .
-                '&token=' . Tools::getAdminTokenLite('AdminModules'),
-            ),
-            'back' => array(
+                    '&token=' . Tools::getAdminTokenLite('AdminModules'),
+            ],
+            'back' => [
                 'href' => AdminController::$currentIndex . '&token=' . Tools::getAdminTokenLite('AdminModules'),
                 'desc' => $this->l('Back to list'),
-            ),
-        );
+            ],
+        ];
         // Load current value
         $helper->fields_value['ESATISFACTION_APP_ID'] = Configuration::get('ESATISFACTION_APP_ID');
         $helper->fields_value['ESATISFACTION_DOMAIN'] = Configuration::get('ESATISFACTION_DOMAIN');
@@ -430,10 +430,10 @@ class Esatisfaction extends Module
             $helper->fields_value['canceled_strpick_os[]_' . $value] = 1;
         }
 
-        $this->context->smarty->assign(array(
+        $this->context->smarty->assign([
             'icon' => $this->defaultImage,
             'name' => $this->name,
-        ));
+        ]);
 
         return $this->context->smarty->fetch($this->local_path . 'views/templates/admin/configure.tpl') . $helper->generateForm($fields_form);
     }
@@ -441,10 +441,11 @@ class Esatisfaction extends Module
     /**
      * Load js file in the configuration page.
      *
-     * @author        e-satisfaction SA
+     * @param array $params
+     *
      * @copyright (c) 2018, e-satisfaction SA
      *
-     * @param array $params
+     * @author        e-satisfaction SA
      */
     public function hookDisplayBackOfficeHeader($params)
     {
@@ -452,18 +453,18 @@ class Esatisfaction extends Module
             return;
         }
         $this->context->controller->addJquery();
-        $this->context->controller->addJS($this->_path.'views/js/admin.js');
+        $this->context->controller->addJS($this->_path . 'views/js/admin.js');
     }
 
     /**
      * Hook after an order is validated.
      *
-     * @author        e-satisfaction SA
-     * @copyright (c) 2018, e-satisfaction SA
-     *
      * @param array $params
      *
      * @return bool
+     * @author        e-satisfaction SA
+     * @copyright (c) 2018, e-satisfaction SA
+     *
      */
     public function hookDisplayOrderConfirmation($params)
     {
@@ -482,7 +483,7 @@ class Esatisfaction extends Module
 
         $app_id = Configuration::get('ESATISFACTION_APP_ID');
         $quest_id = Configuration::get('ESATISFACTION_CHKOUTID');
-        $this->context->smarty->assign(array(
+        $this->context->smarty->assign([
             'order_id' => $params['objOrder']->id,
             'order_date' => $params['objOrder']->date_add,
             'app_id' => $app_id,
@@ -490,7 +491,7 @@ class Esatisfaction extends Module
             'customer_phone' => $invoice_address->phone_mobile,
             'is_store_pickup' => $is_store_pickup,
             'customer_email' => $customer->email,
-        ));
+        ]);
 
         return $this->display(__FILE__, 'checkout.tpl');
     }
@@ -498,18 +499,18 @@ class Esatisfaction extends Module
     /**
      * Add script in header
      *
-     * @author        e-satisfaction SA
-     * @copyright (c) 2018, e-satisfaction SA
-     *
      * @param array $params
      *
      * @return string
+     * @author        e-satisfaction SA
+     * @copyright (c) 2018, e-satisfaction SA
+     *
      */
     public function hookDisplayHeader($params)
     {
-        $this->context->smarty->assign(array(
+        $this->context->smarty->assign([
             'app_id' => Configuration::get('ESATISFACTION_APP_ID'),
-        ));
+        ]);
 
         return $this->display(__FILE__, 'header.tpl');
     }
@@ -517,12 +518,12 @@ class Esatisfaction extends Module
     /**
      * Add or remove an item from the queue list if manual send is enabled
      *
-     * @author        e-satisfaction SA
-     * @copyright (c) 2018, e-satisfaction SA
-     *
      * @param array $params
      *
      * @throws Exception
+     * @author        e-satisfaction SA
+     * @copyright (c) 2018, e-satisfaction SA
+     *
      */
     public function hookActionOrderStatusPostUpdate($params)
     {
@@ -557,9 +558,6 @@ class Esatisfaction extends Module
     /**
      * Make the API call
      *
-     * @author        e-satisfaction SA
-     * @copyright (c) 2018, e-satisfaction SA
-     *
      * @param string $url
      * @param array  $data
      * @param string $expected_code
@@ -567,8 +565,11 @@ class Esatisfaction extends Module
      * @param array  $extra_options
      *
      * @return mixed
+     * @author        e-satisfaction SA
+     * @copyright (c) 2018, e-satisfaction SA
+     *
      */
-    public function makeApiCall($url, $data, $expected_code, $method = null, $extra_options = array())
+    public function makeApiCall($url, $data, $expected_code, $method = null, $extra_options = [])
     {
         // e-satisfaction API base url
         $baseUrl = 'https://api.e-satisfaction.com/v3.2';
@@ -576,13 +577,13 @@ class Esatisfaction extends Module
         $auth = Configuration::get('ESATISFACTION_AUTH');
         $domain = Configuration::get('ESATISFACTION_DOMAIN');
         $ch = curl_init();
-        curl_setopt_array($ch, array(
+        curl_setopt_array($ch, [
             CURLOPT_URL => sprintf('%s/%s', $baseUrl, $url),
             CURLOPT_HEADER => false,
             CURLOPT_RETURNTRANSFER => 1,
             CURLOPT_SSL_VERIFYPEER => false,
-            CURLOPT_HTTPHEADER => array('esat-auth: ' . $auth, 'esat-domain: ' . $domain),
-        ));
+            CURLOPT_HTTPHEADER => ['esat-auth: ' . $auth, 'esat-domain: ' . $domain],
+        ]);
 
         if ($method) {
             curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
@@ -606,15 +607,15 @@ class Esatisfaction extends Module
     /**
      * Send the questionnaire
      *
-     * @author        e-satisfaction SA
-     * @copyright (c) 2018, e-satisfaction SA
-     *
      * @param object $order_obj
      * @param object $customer
      * @param object $invoice_address
      * @param bool   $is_store_pickup
      *
      * @throws Exception
+     * @copyright (c) 2018, e-satisfaction SA
+     *
+     * @author        e-satisfaction SA
      */
     public function sendQuestionnaire($order_obj, $customer, $invoice_address, $is_store_pickup)
     {
@@ -626,20 +627,20 @@ class Esatisfaction extends Module
         $url = sprintf('/q/questionnaire/%s/pipeline/%s/queue/item', $questionnaireId, $pipelineId);
 
         // Create data
-        $data = array(
+        $data = [
             'responder_channel_identifier' => $customer->email,
             'locale' => Language::getIsoById($customer->id_lang),
-            'metadata' => array(
-                'questionnaire' => array(
+            'metadata' => [
+                'questionnaire' => [
                     'transaction_id' => sprintf('%s (%s)', $order_obj->id, $order_obj->reference),
                     'transaction_date' => $order_obj->date_add,
-                ),
-                'responder' => array(
-                      'email' => $customer->email,
-                      'phone_number' => $invoice_address->phone_mobile,
-                ),
-            ),
-        );
+                ],
+                'responder' => [
+                    'email' => $customer->email,
+                    'phone_number' => $invoice_address->phone_mobile,
+                ],
+            ],
+        ];
 
         // Check for delay days
         $delayDays = Configuration::get('ESATISFACTION_HOMEDLVID_DAYS');
@@ -659,19 +660,20 @@ class Esatisfaction extends Module
     /**
      * Remove item from queue
      *
-     * @author        e-satisfaction SA
+     * @param object $order_obj
+     *
      * @copyright (c) 2018, e-satisfaction SA
      *
-     * @param object $order_obj
+     * @author        e-satisfaction SA
      */
     public function cancelQuestionnaire($order_obj)
     {
         $item_id = $this->getQueueItem($order_obj->id);
         $url = sprintf('/q/queue/item/%s', $item_id);
-        $data = array(
+        $data = [
             'status_id' => 5,
             'result' => 'Order cancelled from Prestashop Admin',
-        );
+        ];
         $res = $this->makeApiCall($url, $data, '200', 'PATCH');
         if ($res !== false) {
             $this->deleteQueueItem($order_obj->id);
@@ -681,19 +683,19 @@ class Esatisfaction extends Module
     /**
      * Create or update item_id and order_id in the database
      *
-     * @author        e-satisfaction SA
-     * @copyright (c) 2018, e-satisfaction SA
-     *
      * @param int    $order_id
      * @param string $item_id
      *
      * @return bool
+     * @copyright (c) 2018, e-satisfaction SA
+     *
+     * @author        e-satisfaction SA
      */
     public function insertQueueItem($order_id, $item_id)
     {
         return Db::getInstance()->insert(
             'esat_order_stat',
-            array('order_id' => $order_id, 'item_id' => $item_id),
+            ['order_id' => $order_id, 'item_id' => $item_id],
             false,
             true,
             Db::REPLACE
@@ -703,12 +705,12 @@ class Esatisfaction extends Module
     /**
      * Get the item_id from the database
      *
-     * @author        e-satisfaction SA
-     * @copyright (c) 2018, e-satisfaction SA
-     *
      * @param int $order_id
      *
      * @return bool
+     * @author        e-satisfaction SA
+     * @copyright (c) 2018, e-satisfaction SA
+     *
      */
     public function getQueueItem($order_id)
     {
@@ -720,10 +722,11 @@ class Esatisfaction extends Module
     /**
      * Remove item_id from the database
      *
-     * @author        e-satisfaction SA
+     * @param int $order_id
+     *
      * @copyright (c) 2018, e-satisfaction SA
      *
-     * @param int $order_id
+     * @author        e-satisfaction SA
      */
     public function deleteQueueItem($order_id)
     {

--- a/index.php
+++ b/index.php
@@ -25,7 +25,7 @@
 */
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
-header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 
 header('Cache-Control: no-store, no-cache, must-revalidate');
 header('Cache-Control: post-check=0, pre-check=0', false);

--- a/views/css/index.php
+++ b/views/css/index.php
@@ -25,7 +25,7 @@
 */
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
-header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 
 header('Cache-Control: no-store, no-cache, must-revalidate');
 header('Cache-Control: post-check=0, pre-check=0', false);

--- a/views/img/index.php
+++ b/views/img/index.php
@@ -25,7 +25,7 @@
 */
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
-header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 
 header('Cache-Control: no-store, no-cache, must-revalidate');
 header('Cache-Control: post-check=0, pre-check=0', false);

--- a/views/index.php
+++ b/views/index.php
@@ -25,7 +25,7 @@
 */
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
-header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 
 header('Cache-Control: no-store, no-cache, must-revalidate');
 header('Cache-Control: post-check=0, pre-check=0', false);

--- a/views/js/admin.js
+++ b/views/js/admin.js
@@ -7,8 +7,8 @@
  *
  * You must not modify, adapt or create derivative works of this source code
  *
- * @author    e-satisfaction SA
- * @copyright 2018 e-satisfaction SA
+ * @author    e-satisfaction.com
+ * @copyright 2020 e-satisfaction.com
  * @license   https://opensource.org/licenses
  * @version   1.1.1
  */

--- a/views/js/admin.js
+++ b/views/js/admin.js
@@ -10,7 +10,7 @@
  * @author    e-satisfaction SA
  * @copyright 2018 e-satisfaction SA
  * @license   https://opensource.org/licenses
- * @version   1.1.0
+ * @version   1.1.1
  */
 (function ($) {
     $(document).on('ready', function () {

--- a/views/js/index.php
+++ b/views/js/index.php
@@ -25,7 +25,7 @@
 */
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
-header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 
 header('Cache-Control: no-store, no-cache, must-revalidate');
 header('Cache-Control: post-check=0, pre-check=0', false);

--- a/views/templates/admin/configure.tpl
+++ b/views/templates/admin/configure.tpl
@@ -7,8 +7,8 @@
  *
  * You must not modify, adapt or create derivative works of this source code
  *
- *  @author    e-satisfaction SA
- *  @copyright 2016 e-satisfaction SA
+ *  @author    e-satisfaction.com
+ *  @copyright 2020, e-satisfaction.com
  *  @license   https://opensource.org/licenses
  *}
 <div class="row">

--- a/views/templates/admin/index.php
+++ b/views/templates/admin/index.php
@@ -25,7 +25,7 @@
 */
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
-header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 
 header('Cache-Control: no-store, no-cache, must-revalidate');
 header('Cache-Control: post-check=0, pre-check=0', false);

--- a/views/templates/hook/checkout.tpl
+++ b/views/templates/hook/checkout.tpl
@@ -7,8 +7,8 @@
  *
  * You must not modify, adapt or create derivative works of this source code
  *
- *  @author    e-satisfaction SA
- *  @copyright 2018 e-satisfaction SA
+ *  @author    e-satisfaction.com
+ *  @copyright 2020-satisfaction SA
  *  @license   https://opensource.org/licenses
  *}
 <!-- E-sat order confirmation code -->

--- a/views/templates/hook/header.tpl
+++ b/views/templates/hook/header.tpl
@@ -7,8 +7,8 @@
  *
  * You must not modify, adapt or create derivative works of this source code
  *
- *  @author    e-satisfaction SA
- *  @copyright 2018 e-satisfaction SA
+ *  @author    e-satisfaction.com
+ *  @copyright 2020 e-satisfaction.com
  *  @license   https://opensource.org/licenses
  *}
 <!-- E-sat header code -->

--- a/views/templates/hook/index.php
+++ b/views/templates/hook/index.php
@@ -25,7 +25,7 @@
 */
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
-header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 
 header('Cache-Control: no-store, no-cache, must-revalidate');
 header('Cache-Control: post-check=0, pre-check=0', false);

--- a/views/templates/index.php
+++ b/views/templates/index.php
@@ -25,7 +25,7 @@
 */
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
-header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 
 header('Cache-Control: no-store, no-cache, must-revalidate');
 header('Cache-Control: post-check=0, pre-check=0', false);


### PR DESCRIPTION
Use both order id and order reference to help customers align the metadata with the order reference they get from the e-shop