### PR TITLE
Include order reference in transaction_id metadata (Presta 1.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ in all versions (major and minor)
 To get the diff for a specific change, go to https://github.com/esatisfaction/esat-prestashop/commit/XXX where
 XXX is the change hash
 
+* 1.1.1
+  * Include order reference in transaction_id metadata
 * 1.1.0
   * Use e-satisfaction working domain
   * Work with api v3.2

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 e-satisfaction SA
+Copyright (c) 2020 e-satisfaction.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>esatisfaction</name>
     <displayName><![CDATA[E-satisfaction Module]]></displayName>
-    <version><![CDATA[1.1.0]]></version>
+    <version><![CDATA[1.1.1]]></version>
     <description><![CDATA[Adds the code necessary to gather customer satisfaction data]]></description>
     <author><![CDATA[e-satisfaction SA]]></author>
     <tab><![CDATA[analytics_stats]]></tab>

--- a/config.xml
+++ b/config.xml
@@ -4,7 +4,7 @@
     <displayName><![CDATA[E-satisfaction Module]]></displayName>
     <version><![CDATA[1.1.1]]></version>
     <description><![CDATA[Adds the code necessary to gather customer satisfaction data]]></description>
-    <author><![CDATA[e-satisfaction SA]]></author>
+    <author><![CDATA[e-satisfaction.com]]></author>
     <tab><![CDATA[analytics_stats]]></tab>
     <is_configurable>1</is_configurable>
     <need_instance>0</need_instance>

--- a/esatisfaction.php
+++ b/esatisfaction.php
@@ -621,7 +621,7 @@ class Esatisfaction extends Module
             'locale' => Language::getIsoById($customer->id_lang),
             'metadata' => array(
                 'questionnaire' => array(
-                    'transaction_id' => $order_obj->id,
+                    'transaction_id' => sprintf('%s (%s)', $order_obj->id, $order_obj->reference),
                     'transaction_date' => $order_obj->date_add,
                 ),
                 'responder' => array(

--- a/esatisfaction.php
+++ b/esatisfaction.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * NOTICE OF LICENSE.
  *
@@ -8,12 +9,15 @@
  *
  * You must not modify, adapt or create derivative works of this source code
  *
- * @author    e-satisfaction SA
- * @copyright 2018 e-satisfaction SA
+ * @author    e-satisfaction.com
+ * @copyright 2020, e-satisfaction.com
  * @license   https://opensource.org/licenses
  * @version   1.1.1
  */
 
+/**
+ * Class Esatisfaction
+ */
 class Esatisfaction extends Module
 {
     /**
@@ -33,8 +37,8 @@ class Esatisfaction extends Module
     {
         $this->name = 'esatisfaction';
         $this->tab = 'other';
-        $this->version = '1.1.0';
-        $this->author = 'e-satisfaction SA';
+        $this->version = '1.1.1';
+        $this->author = 'e-satisfaction.com';
         $this->tab = 'analytics_stats';
         $this->need_instance = 0;
         $this->ps_versions_compliancy = ['min' => '1.7', 'max' => '1.7.99.99'];
@@ -54,8 +58,9 @@ class Esatisfaction extends Module
      * actionOrderStatusPostUpdate, displayHeader, displayBackOfficeHeader
      *
      * @return bool
-     * @copyright (c) 2018, e-satisfaction SA
-     * @author        e-satisfaction SA
+     *
+     * @copyright (c) 2020, e-satisfaction.com
+     * @author        e-satisfaction.com
      */
     public function install()
     {
@@ -81,8 +86,9 @@ class Esatisfaction extends Module
      * Load the configuration page.
      *
      * @return string
-     * @copyright (c) 2018, e-satisfaction SA
-     * @author        e-satisfaction SA
+     *
+     * @copyright (c) 2020, e-satisfaction.com
+     * @author        e-satisfaction.com
      */
     public function getContent()
     {
@@ -125,8 +131,9 @@ class Esatisfaction extends Module
      * Display module configuration form.
      *
      * @return string
-     * @copyright (c) 2018, e-satisfaction SA
-     * @author        e-satisfaction SA
+     *
+     * @copyright (c) 2020, e-satisfaction.com
+     * @author        e-satisfaction.com
      */
     public function displayForm()
     {
@@ -438,9 +445,8 @@ class Esatisfaction extends Module
      *
      * @param array $params
      *
-     * @copyright (c) 2018, e-satisfaction SA
-     *
-     * @author        e-satisfaction SA
+     * @copyright (c) 2020, e-satisfaction.com
+     * @author        e-satisfaction.com
      */
     public function hookDisplayBackOfficeHeader($params)
     {
@@ -457,9 +463,9 @@ class Esatisfaction extends Module
      * @param array $params
      *
      * @return bool
-     * @author        e-satisfaction SA
-     * @copyright (c) 2018, e-satisfaction SA
      *
+     * @copyright (c) 2020, e-satisfaction.com
+     * @author        e-satisfaction.com
      */
     public function hookDisplayOrderConfirmation($params)
     {
@@ -493,9 +499,9 @@ class Esatisfaction extends Module
      * @param array $params
      *
      * @return string
-     * @author        e-satisfaction SA
-     * @copyright (c) 2018, e-satisfaction SA
      *
+     * @copyright (c) 2020, e-satisfaction.com
+     * @author        e-satisfaction.com
      */
     public function hookDisplayHeader($params)
     {
@@ -512,9 +518,9 @@ class Esatisfaction extends Module
      * @param array $params
      *
      * @throws Exception
-     * @author        e-satisfaction SA
-     * @copyright (c) 2018, e-satisfaction SA
      *
+     * @copyright (c) 2020, e-satisfaction.com
+     * @author        e-satisfaction.com
      */
     public function hookActionOrderStatusPostUpdate($params)
     {
@@ -555,9 +561,9 @@ class Esatisfaction extends Module
      * @param array  $extra_options
      *
      * @return mixed
-     * @author        e-satisfaction SA
-     * @copyright (c) 2018, e-satisfaction SA
      *
+     * @copyright (c) 2020, e-satisfaction.com
+     * @author        e-satisfaction.com
      */
     public function makeApiCall($url, $data, $expected_code, $method = null, $extra_options = [])
     {
@@ -603,9 +609,9 @@ class Esatisfaction extends Module
      * @param bool   $is_store_pickup
      *
      * @throws Exception
-     * @copyright (c) 2018, e-satisfaction SA
      *
-     * @author        e-satisfaction SA
+     * @copyright (c) 2020, e-satisfaction.com
+     * @author        e-satisfaction.com
      */
     public function sendQuestionnaire($order_obj, $customer, $invoice_address, $is_store_pickup)
     {
@@ -652,9 +658,8 @@ class Esatisfaction extends Module
      *
      * @param object $order_obj
      *
-     * @copyright (c) 2018, e-satisfaction SA
-     *
-     * @author        e-satisfaction SA
+     * @copyright (c) 2020, e-satisfaction.com
+     * @author        e-satisfaction.com
      */
     public function cancelQuestionnaire($order_obj)
     {
@@ -677,9 +682,9 @@ class Esatisfaction extends Module
      * @param string $item_id
      *
      * @return bool
-     * @copyright (c) 2018, e-satisfaction SA
      *
-     * @author        e-satisfaction SA
+     * @copyright (c) 2020, e-satisfaction.com
+     * @author        e-satisfaction.com
      */
     public function insertQueueItem($order_id, $item_id)
     {
@@ -698,9 +703,9 @@ class Esatisfaction extends Module
      * @param int $order_id
      *
      * @return object
-     * @author        e-satisfaction SA
-     * @copyright (c) 2018, e-satisfaction SA
      *
+     * @copyright (c) 2020, e-satisfaction.com
+     * @author        e-satisfaction.com
      */
     public function getQueueItem($order_id)
     {
@@ -714,9 +719,8 @@ class Esatisfaction extends Module
      *
      * @param int $order_id
      *
-     * @copyright (c) 2018, e-satisfaction SA
-     *
-     * @author        e-satisfaction SA
+     * @copyright (c) 2020, e-satisfaction.com
+     * @author        e-satisfaction.com
      */
     public function deleteQueueItem($order_id)
     {

--- a/esatisfaction.php
+++ b/esatisfaction.php
@@ -37,7 +37,7 @@ class Esatisfaction extends Module
         $this->author = 'e-satisfaction SA';
         $this->tab = 'analytics_stats';
         $this->need_instance = 0;
-        $this->ps_versions_compliancy = array('min' => '1.7', 'max' => '1.7.99.99');
+        $this->ps_versions_compliancy = ['min' => '1.7', 'max' => '1.7.99.99'];
         $this->module_key = '5cd651fbc7befadc249391eb1ef2bf7d';
         $this->bootstrap = true;
         parent::__construct();
@@ -53,9 +53,9 @@ class Esatisfaction extends Module
      * Install module and register it for hooks displayOrderConfirmation,
      * actionOrderStatusPostUpdate, displayHeader, displayBackOfficeHeader
      *
-     * @author        e-satisfaction SA
-     * @copyright (c) 2018, e-satisfaction SA
      * @return bool
+     * @copyright (c) 2018, e-satisfaction SA
+     * @author        e-satisfaction SA
      */
     public function install()
     {
@@ -80,9 +80,9 @@ class Esatisfaction extends Module
     /**
      * Load the configuration page.
      *
-     * @author        e-satisfaction SA
-     * @copyright (c) 2018, e-satisfaction SA
      * @return string
+     * @copyright (c) 2018, e-satisfaction SA
+     * @author        e-satisfaction SA
      */
     public function getContent()
     {
@@ -124,9 +124,9 @@ class Esatisfaction extends Module
     /**
      * Display module configuration form.
      *
-     * @author        e-satisfaction SA
-     * @copyright (c) 2018, e-satisfaction SA
      * @return string
+     * @copyright (c) 2018, e-satisfaction SA
+     * @author        e-satisfaction SA
      */
     public function displayForm()
     {
@@ -136,229 +136,229 @@ class Esatisfaction extends Module
         $default_lang = (int)Configuration::get('PS_LANG_DEFAULT');
 
         $carriers_raw = Carrier::getCarriers($default_lang, true, false);
-        $carriers = array();
+        $carriers = [];
         foreach ($carriers_raw as $carrier) {
-            $carriers[] = array(
+            $carriers[] = [
                 'val' => $carrier['id_reference'],
                 'carrier_reference' => $carrier['id_reference'],
-                'name' => $carrier['name'], );
+                'name' => $carrier['name'],];
         }
 
         $order_statuses_raw = OrderState::getOrderStates($default_lang);
-        $order_statuses = array();
+        $order_statuses = [];
         foreach ($order_statuses_raw as $order_status) {
-            $order_statuses[] = array(
+            $order_statuses[] = [
                 'val' => $order_status['id_order_state'],
                 'order_state_id' => $order_status['id_order_state'],
                 'name' => $order_status['name'],
-            );
+            ];
         }
 
         // Init Fields form array
-        $fields_form[0]['form'] = array(
-            'legend' => array(
+        $fields_form[0]['form'] = [
+            'legend' => [
                 'title' => $this->l('Application'),
-            ),
-            'input' => array(
-                array(
+            ],
+            'input' => [
+                [
                     'type' => 'text',
                     'label' => $this->l('Application Id'),
                     'name' => 'ESATISFACTION_APP_ID',
                     'size' => 20,
                     'required' => true,
-                ),
-                array(
+                ],
+                [
                     'type' => 'text',
                     'label' => $this->l('Working Domain'),
                     'name' => 'ESATISFACTION_DOMAIN',
                     'size' => 20,
                     'required' => true,
-                ),
-            ),
-            'submit' => array(
+                ],
+            ],
+            'submit' => [
                 'title' => $this->l('Save'),
                 'class' => 'btn btn-default',
-            ),
-        );
-        $fields_form[1]['form'] = array(
-            'legend' => array(
+            ],
+        ];
+        $fields_form[1]['form'] = [
+            'legend' => [
                 'title' => $this->l('Checkout Questionnaire'),
-            ),
-            'input' => array(
-                array(
+            ],
+            'input' => [
+                [
                     'type' => 'text',
                     'label' => $this->l('Questionnaire Id'),
                     'name' => 'ESATISFACTION_CHKOUTID',
                     'size' => 45,
                     'required' => true,
-                ),
-            ),
-            'submit' => array(
+                ],
+            ],
+            'submit' => [
                 'title' => $this->l('Save'),
                 'class' => 'btn btn-default',
-            ),
-        );
+            ],
+        ];
 
-        $fields_form[2]['form'] = array(
-            'legend' => array(
+        $fields_form[2]['form'] = [
+            'legend' => [
                 'title' => $this->l('Manually sending After Delivery / Store Pickup'),
-            ),
-            'input' => array(
-                array(
+            ],
+            'input' => [
+                [
                     'type' => 'switch',
                     'label' => $this->l('Send Manually'),
                     'name' => 'manual_send',
                     'is_bool' => true,
-                    'values' => array(
-                        array(
+                    'values' => [
+                        [
                             'id' => 'manual_send_on',
                             'value' => 1,
                             'label' => $this->l('Enabled'),
-                        ),
-                        array(
+                        ],
+                        [
                             'id' => 'manual_send_off',
                             'value' => 0,
                             'label' => $this->l('Disabled'),
-                        ),
-                    ),
-                ),
-            ),
-            'submit' => array(
+                        ],
+                    ],
+                ],
+            ],
+            'submit' => [
                 'title' => $this->l('Save'),
                 'class' => 'btn btn-default',
-            ),
-        );
+            ],
+        ];
 
-        $fields_form[3]['form'] = array(
-            'legend' => array(
+        $fields_form[3]['form'] = [
+            'legend' => [
                 'title' => $this->l('API Authentication Token'),
-            ),
-            'input' => array(
-                array(
+            ],
+            'input' => [
+                [
                     'type' => 'text',
                     'label' => $this->l('Token'),
                     'name' => 'ESATISFACTION_AUTH',
                     'size' => 45,
-                ),
-            ),
-            'submit' => array(
+                ],
+            ],
+            'submit' => [
                 'title' => $this->l('Save'),
                 'class' => 'btn btn-default',
-            ),
-        );
+            ],
+        ];
 
-        $fields_form[4]['form'] = array(
-            'legend' => array(
+        $fields_form[4]['form'] = [
+            'legend' => [
                 'title' => $this->l('After Delivery Questionnaire'),
-            ),
-            'input' => array(
-                array(
+            ],
+            'input' => [
+                [
                     'type' => 'text',
                     'label' => $this->l('Questionnaire Id'),
                     'name' => 'ESATISFACTION_HOMEDLVID',
                     'size' => 45,
-                ),
-                array(
+                ],
+                [
                     'type' => 'text',
                     'label' => $this->l('Pipeline Id'),
                     'name' => 'ESATISFACTION_HOMEDLV_PIPE_ID',
                     'size' => 45,
-                ),
-                array(
+                ],
+                [
                     'type' => 'text',
                     'label' => $this->l('Days after to send questionnaire'),
                     'name' => 'ESATISFACTION_HOMEDLVID_DAYS',
                     'size' => 4,
-                ),
-                array(
+                ],
+                [
                     'type' => 'checkbox',
                     'label' => $this->l('Order status(es) to send questionnaire'),
                     'name' => 'delivered_dlv_os[]',
-                    'values'  => array(
-                       'query' => $order_statuses,
-                       'id' => 'order_state_id',
-                       'name'  => 'name',
-                    ),
-                ),
-                array(
+                    'values' => [
+                        'query' => $order_statuses,
+                        'id' => 'order_state_id',
+                        'name' => 'name',
+                    ],
+                ],
+                [
                     'type' => 'checkbox',
                     'label' => $this->l('Condition to determine when it’s after delivery'),
                     'name' => 'courier_carriers[]',
                     'desc' => 'Select the carriers that are used for after delivery',
-                    'values'  => array(
-                       'query' => $carriers,
-                       'id' => 'carrier_reference',
-                       'name'  => 'name',
-                ), ),
-                array(
+                    'values' => [
+                        'query' => $carriers,
+                        'id' => 'carrier_reference',
+                        'name' => 'name',
+                    ],],
+                [
                     'type' => 'checkbox',
                     'label' => $this->l('Order status(es) to cancel questionnaire'),
                     'name' => 'canceled_dlv_os[]',
-                    'values'  => array(
-                       'query' => $order_statuses,
-                       'id' => 'order_state_id',
-                       'name'  => 'name',
-                    ),
-                ),
-            ),
-            'submit' => array(
+                    'values' => [
+                        'query' => $order_statuses,
+                        'id' => 'order_state_id',
+                        'name' => 'name',
+                    ],
+                ],
+            ],
+            'submit' => [
                 'title' => $this->l('Save'),
                 'class' => 'btn btn-default',
-            ),
-        );
-        $fields_form[5]['form'] = array(
-            'legend' => array(
+            ],
+        ];
+        $fields_form[5]['form'] = [
+            'legend' => [
                 'title' => $this->l('Store Pick Up Questionnaire'),
-            ),
-            'input' => array(
-                array(
+            ],
+            'input' => [
+                [
                     'type' => 'text',
                     'label' => $this->l('Questionnaire Id'),
                     'name' => 'ESATISFACTION_STRPICKID',
                     'size' => 45,
-                ),
-                array(
+                ],
+                [
                     'type' => 'text',
                     'label' => $this->l('Pipeline Id'),
                     'name' => 'ESATISFACTION_STRPICK_PIPE_ID',
                     'size' => 45,
-                ),
-                array(
+                ],
+                [
                     'type' => 'checkbox',
                     'label' => $this->l('Order status(es) to send questionnaire'),
                     'name' => 'delivered_strpick_os[]',
-                    'values'  => array(
-                       'query' => $order_statuses,
-                       'id' => 'order_state_id',
-                       'name'  => 'name',
-                    ),
-                ),
-                array(
+                    'values' => [
+                        'query' => $order_statuses,
+                        'id' => 'order_state_id',
+                        'name' => 'name',
+                    ],
+                ],
+                [
                     'type' => 'checkbox',
                     'label' => $this->l('Condition to determine when it’s store pickup'),
                     'name' => 'store_pickup_carriers[]',
                     'desc' => 'Select the carriers that are used for store pickup',
-                    'values'  => array(
-                       'query' => $carriers,
-                       'id' => 'carrier_reference',
-                       'name'  => 'name',
-                ), ),
-                array(
+                    'values' => [
+                        'query' => $carriers,
+                        'id' => 'carrier_reference',
+                        'name' => 'name',
+                    ],],
+                [
                     'type' => 'checkbox',
                     'label' => $this->l('Order status(es) to cancel questionnaire'),
                     'name' => 'canceled_strpick_os[]',
-                    'values'  => array(
-                       'query' => $order_statuses,
-                       'id' => 'order_state_id',
-                       'name'  => 'name',
-                    ),
-                ),
-            ),
-            'submit' => array(
+                    'values' => [
+                        'query' => $order_statuses,
+                        'id' => 'order_state_id',
+                        'name' => 'name',
+                    ],
+                ],
+            ],
+            'submit' => [
                 'title' => $this->l('Save'),
                 'class' => 'btn btn-default',
-            ),
-        );
+            ],
+        ];
 
         $helper = new HelperForm();
 
@@ -377,16 +377,16 @@ class Esatisfaction extends Module
         $helper->show_toolbar = true; // false -> remove toolbar
         $helper->toolbar_scroll = true;      // yes - > Toolbar is always visible on the top of the screen.
         $helper->submit_action = 'submit' . $this->name;
-        $helper->toolbar_btn = array(
-            'save' => array(
+        $helper->toolbar_btn = [
+            'save' => [
                 'desc' => $this->l('Save'),
                 'href' => AdminController::$currentIndex . '&configure=' . $this->name . '&save' . $this->name . '&token=' . Tools::getAdminTokenLite('AdminModules'),
-            ),
-            'back' => array(
+            ],
+            'back' => [
                 'href' => AdminController::$currentIndex . '&token=' . Tools::getAdminTokenLite('AdminModules'),
                 'desc' => $this->l('Back to list'),
-            ),
-        );
+            ],
+        ];
         // Load current value
         $helper->fields_value['ESATISFACTION_APP_ID'] = Configuration::get('ESATISFACTION_APP_ID');
         $helper->fields_value['ESATISFACTION_DOMAIN'] = Configuration::get('ESATISFACTION_DOMAIN');
@@ -401,34 +401,34 @@ class Esatisfaction extends Module
 
         $delivered_dlv_os = json_decode(Configuration::get('ESATISFACTION_DELIVERED_DLV_OS_IDS'));
         foreach ($delivered_dlv_os as $value) {
-            $helper->fields_value['delivered_dlv_os[]_'.$value] = 1;
+            $helper->fields_value['delivered_dlv_os[]_' . $value] = 1;
         }
         $courier_carriers = json_decode(Configuration::get('ESATISFACTION_COURIER_IDS'));
         foreach ($courier_carriers as $value) {
-            $helper->fields_value['courier_carriers[]_'.$value] = 1;
+            $helper->fields_value['courier_carriers[]_' . $value] = 1;
         }
         $canceled_dlv_os = json_decode(Configuration::get('ESATISFACTION_CANCELED_DLV_OS_IDS'));
         foreach ($canceled_dlv_os as $value) {
-            $helper->fields_value['canceled_dlv_os[]_'.$value] = 1;
+            $helper->fields_value['canceled_dlv_os[]_' . $value] = 1;
         }
 
         $delivered_strpick_os = json_decode(Configuration::get('ESATISFACTION_DELIVERED_STRPICK_OS_IDS'));
         foreach ($delivered_strpick_os as $value) {
-            $helper->fields_value['delivered_strpick_os[]_'.$value] = 1;
+            $helper->fields_value['delivered_strpick_os[]_' . $value] = 1;
         }
         $store_pickup_carriers = json_decode(Configuration::get('ESATISFACTION_STOREPICKUP_IDS'));
         foreach ($store_pickup_carriers as $value) {
-            $helper->fields_value['store_pickup_carriers[]_'.$value] = 1;
+            $helper->fields_value['store_pickup_carriers[]_' . $value] = 1;
         }
         $canceled_strpick_os = json_decode(Configuration::get('ESATISFACTION_CANCELED_STRPICK_OS_IDS'));
         foreach ($canceled_strpick_os as $value) {
-            $helper->fields_value['canceled_strpick_os[]_'.$value] = 1;
+            $helper->fields_value['canceled_strpick_os[]_' . $value] = 1;
         }
 
-        $this->context->smarty->assign(array(
+        $this->context->smarty->assign([
             'icon' => $this->defaultImage,
             'name' => $this->name,
-        ));
+        ]);
 
         return $this->context->smarty->fetch($this->local_path . 'views/templates/admin/configure.tpl') . $helper->generateForm($fields_form);
     }
@@ -436,10 +436,11 @@ class Esatisfaction extends Module
     /**
      * Load js file in the configuration page.
      *
-     * @author        e-satisfaction SA
+     * @param array $params
+     *
      * @copyright (c) 2018, e-satisfaction SA
      *
-     * @param array $params
+     * @author        e-satisfaction SA
      */
     public function hookDisplayBackOfficeHeader($params)
     {
@@ -453,12 +454,12 @@ class Esatisfaction extends Module
     /**
      * Hook after an order is validated.
      *
-     * @author        e-satisfaction SA
-     * @copyright (c) 2018, e-satisfaction SA
-     *
      * @param array $params
      *
      * @return bool
+     * @author        e-satisfaction SA
+     * @copyright (c) 2018, e-satisfaction SA
+     *
      */
     public function hookDisplayOrderConfirmation($params)
     {
@@ -473,7 +474,7 @@ class Esatisfaction extends Module
 
         $app_id = Configuration::get('ESATISFACTION_APP_ID');
         $quest_id = Configuration::get('ESATISFACTION_CHKOUTID');
-        $this->context->smarty->assign(array(
+        $this->context->smarty->assign([
             'order_id' => $params['order']->id,
             'order_date' => $params['order']->date_add,
             'app_id' => $app_id,
@@ -481,7 +482,7 @@ class Esatisfaction extends Module
             'customer_phone' => $invoice_address->phone_mobile,
             'is_store_pickup' => $is_store_pickup,
             'customer_email' => $customer->email,
-        ));
+        ]);
 
         return $this->display(__FILE__, 'checkout.tpl');
     }
@@ -489,18 +490,18 @@ class Esatisfaction extends Module
     /**
      * Add script in header
      *
-     * @author        e-satisfaction SA
-     * @copyright (c) 2018, e-satisfaction SA
-     *
      * @param array $params
      *
      * @return string
+     * @author        e-satisfaction SA
+     * @copyright (c) 2018, e-satisfaction SA
+     *
      */
     public function hookDisplayHeader($params)
     {
-        $this->context->smarty->assign(array(
+        $this->context->smarty->assign([
             'app_id' => Configuration::get('ESATISFACTION_APP_ID'),
-        ));
+        ]);
 
         return $this->display(__FILE__, 'header.tpl');
     }
@@ -508,12 +509,12 @@ class Esatisfaction extends Module
     /**
      * Add or remove an item from the queue list if manual send is enabled
      *
-     * @author        e-satisfaction SA
-     * @copyright (c) 2018, e-satisfaction SA
-     *
      * @param array $params
      *
      * @throws Exception
+     * @author        e-satisfaction SA
+     * @copyright (c) 2018, e-satisfaction SA
+     *
      */
     public function hookActionOrderStatusPostUpdate($params)
     {
@@ -547,9 +548,6 @@ class Esatisfaction extends Module
     /**
      * Make the API call
      *
-     * @author        e-satisfaction SA
-     * @copyright (c) 2018, e-satisfaction SA
-     *
      * @param string $url
      * @param array  $data
      * @param string $expected_code
@@ -557,8 +555,11 @@ class Esatisfaction extends Module
      * @param array  $extra_options
      *
      * @return mixed
+     * @author        e-satisfaction SA
+     * @copyright (c) 2018, e-satisfaction SA
+     *
      */
-    public function makeApiCall($url, $data, $expected_code, $method = null, $extra_options = array())
+    public function makeApiCall($url, $data, $expected_code, $method = null, $extra_options = [])
     {
         // e-satisfaction API base url
         $baseUrl = 'https://api.e-satisfaction.com/v3.2';
@@ -566,13 +567,13 @@ class Esatisfaction extends Module
         $auth = Configuration::get('ESATISFACTION_AUTH');
         $domain = Configuration::get('ESATISFACTION_DOMAIN');
         $ch = curl_init();
-        curl_setopt_array($ch, array(
+        curl_setopt_array($ch, [
             CURLOPT_URL => sprintf('%s/%s', $baseUrl, $url),
             CURLOPT_HEADER => false,
             CURLOPT_RETURNTRANSFER => 1,
             CURLOPT_SSL_VERIFYPEER => false,
-            CURLOPT_HTTPHEADER => array('esat-auth: ' . $auth, 'esat-domain: ' . $domain),
-        ));
+            CURLOPT_HTTPHEADER => ['esat-auth: ' . $auth, 'esat-domain: ' . $domain],
+        ]);
 
         if ($method) {
             curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
@@ -596,15 +597,15 @@ class Esatisfaction extends Module
     /**
      * Send the questionnaire
      *
-     * @author        e-satisfaction SA
-     * @copyright (c) 2018, e-satisfaction SA
-     *
      * @param object $order_obj
      * @param object $customer
      * @param object $invoice_address
      * @param bool   $is_store_pickup
      *
      * @throws Exception
+     * @copyright (c) 2018, e-satisfaction SA
+     *
+     * @author        e-satisfaction SA
      */
     public function sendQuestionnaire($order_obj, $customer, $invoice_address, $is_store_pickup)
     {
@@ -616,20 +617,20 @@ class Esatisfaction extends Module
         $url = sprintf('/q/questionnaire/%s/pipeline/%s/queue/item', $questionnaireId, $pipelineId);
 
         // Create data
-        $data = array(
+        $data = [
             'responder_channel_identifier' => $customer->email,
             'locale' => Language::getIsoById($customer->id_lang),
-            'metadata' => array(
-                'questionnaire' => array(
+            'metadata' => [
+                'questionnaire' => [
                     'transaction_id' => sprintf('%s (%s)', $order_obj->id, $order_obj->reference),
                     'transaction_date' => $order_obj->date_add,
-                ),
-                'responder' => array(
-                      'email' => $customer->email,
-                      'phone_number' => $invoice_address->phone_mobile,
-                ),
-            ),
-        );
+                ],
+                'responder' => [
+                    'email' => $customer->email,
+                    'phone_number' => $invoice_address->phone_mobile,
+                ],
+            ],
+        ];
 
         // Check for delay days
         $delayDays = Configuration::get('ESATISFACTION_HOMEDLVID_DAYS');
@@ -649,19 +650,20 @@ class Esatisfaction extends Module
     /**
      * Remove item from queue
      *
-     * @author        e-satisfaction SA
+     * @param object $order_obj
+     *
      * @copyright (c) 2018, e-satisfaction SA
      *
-     * @param object $order_obj
+     * @author        e-satisfaction SA
      */
     public function cancelQuestionnaire($order_obj)
     {
         $item_id = $this->getQueueItem($order_obj->id);
         $url = sprintf('/q/queue/item/%s', $item_id);
-        $data = array(
+        $data = [
             'status_id' => 5,
             'result' => 'Order cancelled from Prestashop Admin',
-        );
+        ];
         $res = $this->makeApiCall($url, $data, '200', 'PATCH');
         if ($res !== false) {
             $this->deleteQueueItem($order_obj->id);
@@ -671,19 +673,19 @@ class Esatisfaction extends Module
     /**
      * Create or update item_id and order_id in the database
      *
-     * @author        e-satisfaction SA
-     * @copyright (c) 2018, e-satisfaction SA
-     *
      * @param int    $order_id
      * @param string $item_id
      *
      * @return bool
+     * @copyright (c) 2018, e-satisfaction SA
+     *
+     * @author        e-satisfaction SA
      */
     public function insertQueueItem($order_id, $item_id)
     {
         return Db::getInstance()->insert(
             'esat_order_stat',
-            array('order_id' => $order_id, 'item_id' => $item_id),
+            ['order_id' => $order_id, 'item_id' => $item_id],
             false,
             true,
             Db::REPLACE
@@ -693,16 +695,16 @@ class Esatisfaction extends Module
     /**
      * Get the item_id from the database
      *
-     * @author        e-satisfaction SA
-     * @copyright (c) 2018, e-satisfaction SA
-     *
      * @param int $order_id
      *
      * @return object
+     * @author        e-satisfaction SA
+     * @copyright (c) 2018, e-satisfaction SA
+     *
      */
     public function getQueueItem($order_id)
     {
-        $sql = 'SELECT `item_id` FROM `'. _DB_PREFIX_ .'esat_order_stat` WHERE `order_id` = '.(int)$order_id;
+        $sql = 'SELECT `item_id` FROM `' . _DB_PREFIX_ . 'esat_order_stat` WHERE `order_id` = ' . (int)$order_id;
 
         return Db::getInstance()->getValue($sql);
     }
@@ -710,13 +712,14 @@ class Esatisfaction extends Module
     /**
      * Remove item_id from the database
      *
-     * @author        e-satisfaction SA
+     * @param int $order_id
+     *
      * @copyright (c) 2018, e-satisfaction SA
      *
-     * @param int $order_id
+     * @author        e-satisfaction SA
      */
     public function deleteQueueItem($order_id)
     {
-        Db::getInstance()->delete('esat_order_stat', 'order_id = '.$order_id);
+        Db::getInstance()->delete('esat_order_stat', 'order_id = ' . $order_id);
     }
 }

--- a/esatisfaction.php
+++ b/esatisfaction.php
@@ -11,7 +11,7 @@
  * @author    e-satisfaction SA
  * @copyright 2018 e-satisfaction SA
  * @license   https://opensource.org/licenses
- * @version   1.1.0
+ * @version   1.1.1
  */
 
 class Esatisfaction extends Module

--- a/index.php
+++ b/index.php
@@ -25,7 +25,7 @@
 */
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
-header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 
 header('Cache-Control: no-store, no-cache, must-revalidate');
 header('Cache-Control: post-check=0, pre-check=0', false);

--- a/views/css/index.php
+++ b/views/css/index.php
@@ -25,7 +25,7 @@
 */
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
-header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 
 header('Cache-Control: no-store, no-cache, must-revalidate');
 header('Cache-Control: post-check=0, pre-check=0', false);

--- a/views/img/index.php
+++ b/views/img/index.php
@@ -25,7 +25,7 @@
 */
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
-header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 
 header('Cache-Control: no-store, no-cache, must-revalidate');
 header('Cache-Control: post-check=0, pre-check=0', false);

--- a/views/index.php
+++ b/views/index.php
@@ -25,7 +25,7 @@
 */
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
-header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 
 header('Cache-Control: no-store, no-cache, must-revalidate');
 header('Cache-Control: post-check=0, pre-check=0', false);

--- a/views/js/admin.js
+++ b/views/js/admin.js
@@ -7,8 +7,8 @@
  *
  * You must not modify, adapt or create derivative works of this source code
  *
- * @author    e-satisfaction SA
- * @copyright 2018 e-satisfaction SA
+ * @author    e-satisfaction.com
+ * @copyright 2020, e-satisfaction.com
  * @license   https://opensource.org/licenses
  * @version   1.1.1
  */

--- a/views/js/admin.js
+++ b/views/js/admin.js
@@ -10,7 +10,7 @@
  * @author    e-satisfaction SA
  * @copyright 2018 e-satisfaction SA
  * @license   https://opensource.org/licenses
- * @version   1.1.0
+ * @version   1.1.1
  */
 (function ($) {
     $(document).on('ready', function () {

--- a/views/js/index.php
+++ b/views/js/index.php
@@ -25,7 +25,7 @@
 */
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
-header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 
 header('Cache-Control: no-store, no-cache, must-revalidate');
 header('Cache-Control: post-check=0, pre-check=0', false);

--- a/views/templates/admin/configure.tpl
+++ b/views/templates/admin/configure.tpl
@@ -7,8 +7,8 @@
  *
  * You must not modify, adapt or create derivative works of this source code
  *
- *  @author    e-satisfaction SA
- *  @copyright 2016 e-satisfaction SA
+ *  @author    e-satisfaction.com
+ *  @copyright 2020, e-satisfaction.com
  *  @license   https://opensource.org/licenses
  *}
 <div class="row">

--- a/views/templates/admin/index.php
+++ b/views/templates/admin/index.php
@@ -25,7 +25,7 @@
 */
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
-header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 
 header('Cache-Control: no-store, no-cache, must-revalidate');
 header('Cache-Control: post-check=0, pre-check=0', false);

--- a/views/templates/hook/checkout.tpl
+++ b/views/templates/hook/checkout.tpl
@@ -7,8 +7,8 @@
  *
  * You must not modify, adapt or create derivative works of this source code
  *
- *  @author    e-satisfaction SA
- *  @copyright 2018 e-satisfaction SA
+ *  @author    e-satisfaction.com
+ *  @copyright 2020, e-satisfaction.com
  *  @license   https://opensource.org/licenses
  *}
 <!-- E-sat order confirmation code -->

--- a/views/templates/hook/header.tpl
+++ b/views/templates/hook/header.tpl
@@ -7,8 +7,8 @@
  *
  * You must not modify, adapt or create derivative works of this source code
  *
- *  @author    e-satisfaction SA
- *  @copyright 2018 e-satisfaction SA
+ *  @author    e-satisfaction.com
+ *  @copyright 2020, e-satisfaction.com
  *  @license   https://opensource.org/licenses
  *}
 <!-- E-sat header code -->

--- a/views/templates/hook/index.php
+++ b/views/templates/hook/index.php
@@ -25,7 +25,7 @@
 */
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
-header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 
 header('Cache-Control: no-store, no-cache, must-revalidate');
 header('Cache-Control: post-check=0, pre-check=0', false);

--- a/views/templates/index.php
+++ b/views/templates/index.php
@@ -25,7 +25,7 @@
 */
 
 header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
-header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
 
 header('Cache-Control: no-store, no-cache, must-revalidate');
 header('Cache-Control: post-check=0, pre-check=0', false);


### PR DESCRIPTION
Use both order id and order reference to help customers align the metadata with the order reference they get from the e-shop